### PR TITLE
sound: virtio: Remove virtio_config header from API definitation

### DIFF
--- a/include/uapi/linux/virtio_snd.h
+++ b/include/uapi/linux/virtio_snd.h
@@ -34,7 +34,6 @@
 #include <linux/types.h>
 #include <linux/virtio_types.h>
 #include <linux/virtio_ids.h>
-#include <linux/virtio_config.h>
 
 /*******************************************************************************
  * COMMON DEFINITIONS


### PR DESCRIPTION
The header is not required for the API definitation and results into
redifinition conflicts on QNX

Change-Id: I3b998806451a98f76f8fa9f44f3da88ec4302eba
Signed-off-by: Timo Wischer <twischer@de.adit-jv.com>