### PR TITLE
snd: virtio: Support hardware pointer manipulation from device 

### DIFF
--- a/include/uapi/linux/virtio_snd.h
+++ b/include/uapi/linux/virtio_snd.h
@@ -40,6 +40,8 @@
  * COMMON DEFINITIONS
  */
 
+#define VIRTIO_SND_F_MMAP_HW_PTR	0
+
 /* a configuration space */
 struct virtio_snd_config {
 	/* maximum # of available virtual queues (including the control queue)
@@ -317,6 +319,16 @@ struct virtio_snd_pcm_set_format {
 	__virtio16 rate;
 
 	__u16 padding;
+
+	/* the following is only valid with VIRTIO_SND_F_MMAP_HW_PTR feature */
+	/* start address of data buffer */
+	__virtio64 buffer_address;
+	/* size in bytes of data buffer */
+	__virtio32 buffer_bytes;
+	/* size in bytes of one audio interval/period */
+	__virtio32 period_bytes;
+	/* address of the uint32_t hardware pointer identifing the device position in the audio buffer in frames */
+	__virtio64 hw_pos_address;
 };
 
 /* a maximum possible number of channels */


### PR DESCRIPTION
With this feature the device is able to update the hardware pointer of
the driver without throughing an interrupt. The interrupt is only used
to wake up a blocking application.
With this solution no additional worker thread is required to support
MMAP audio buffers to applications. Therefore no period time estimation
has to be done. The device provides exactly its period time to the
device and application. This means device and driver running synchrone
with the same period size. This avoids additional buffering. Therefore
smaller audio delays can be achieved.

This patch does not change the behaviour when HW_PTR_MAPPING feature is not supported by device.